### PR TITLE
Vector to AbstractVector

### DIFF
--- a/src/NumericalIntegration.jl
+++ b/src/NumericalIntegration.jl
@@ -17,7 +17,7 @@ immutable TrapezoidalEvenFast <: IntegrationMethod end
 immutable SimpsonEven         <: IntegrationMethod end # https://en.wikipedia.org/wiki/Simpson%27s_rule#Alternative_extended_Simpson.27s_rule
 immutable SimpsonEvenFast     <: IntegrationMethod end
 
-function integrate{X<:Real, Y<:Real}(x::Vector{X}, y::Vector{Y}, ::Trapezoidal)
+function integrate{X<:Real, Y<:Real}(x::AbstractVector{X}, y::AbstractVector{Y}, ::Trapezoidal)
   @assert length(x) == length(y) "x and y vectors must be of the same length!"
   retval = zero(promote(x[1], y[1])[1])
     for i in 1 : length(y)-1
@@ -26,12 +26,12 @@ function integrate{X<:Real, Y<:Real}(x::Vector{X}, y::Vector{Y}, ::Trapezoidal)
   return 0.5 * retval
 end
 
-function integrate{X<:Real, Y<:Real}(x::Vector{X}, y::Vector{Y}, ::TrapezoidalEven)
+function integrate{X<:Real, Y<:Real}(x::AbstractVector{X}, y::AbstractVector{Y}, ::TrapezoidalEven)
     @assert length(x) == length(y) "x and y vectors must be of the same length!"
     return 0.5 * (x[end] - x[1]) / (length(y) - 1) * (y[1] + y[end] + sum(y[2:end-1]))
 end
 
-function integrate{X<:Real, Y<:Real}(x::Vector{X}, y::Vector{Y}, ::TrapezoidalFast)
+function integrate{X<:Real, Y<:Real}(x::AbstractVector{X}, y::AbstractVector{Y}, ::TrapezoidalFast)
     retval = zero(promote(x[1], y[1])[1])
     @fastmath @simd for i in 1 : length(y)-1
         @inbounds retval += (x[i+1] - x[i]) * (y[i] + y[i+1])
@@ -39,7 +39,7 @@ function integrate{X<:Real, Y<:Real}(x::Vector{X}, y::Vector{Y}, ::TrapezoidalFa
     return 0.5 * retval
 end
 
-function integrate{X<:Real, Y<:Real}(x::Vector{X}, y::Vector{Y}, ::TrapezoidalEvenFast)
+function integrate{X<:Real, Y<:Real}(x::AbstractVector{X}, y::AbstractVector{Y}, ::TrapezoidalEvenFast)
     retval = zero(promote(x[1], y[1])[1])
     N = length(y) - 1
     @fastmath @simd for i in 2 : N
@@ -48,7 +48,7 @@ function integrate{X<:Real, Y<:Real}(x::Vector{X}, y::Vector{Y}, ::TrapezoidalEv
     @inbounds return (x[end] - x[1]) / N * (retval + 0.5*y[1] + 0.5*y[end])
 end
 
-function integrate{X<:Real, Y<:Real}(x::Vector{X}, y::Vector{Y}, ::SimpsonEven)
+function integrate{X<:Real, Y<:Real}(x::AbstractVector{X}, y::AbstractVector{Y}, ::SimpsonEven)
     @assert length(x) == length(y) "x and y vectors must be of the same length!"
     retval = (17*y[1] + 59*y[2] + 43*y[3] + 49*y[4] + 49*y[end-3] + 43*y[end-2] + 59*y[end-1] + 17*y[end]) / 48
     for i in 5 : length(y) - 1
@@ -57,7 +57,7 @@ function integrate{X<:Real, Y<:Real}(x::Vector{X}, y::Vector{Y}, ::SimpsonEven)
     return (x[end] - x[1]) / (length(y) - 1) * retval
 end
 
-function integrate{X<:Real, Y<:Real}(x::Vector{X}, y::Vector{Y}, ::SimpsonEvenFast)
+function integrate{X<:Real, Y<:Real}(x::AbstractVector{X}, y::AbstractVector{Y}, ::SimpsonEvenFast)
     @inbounds retval = 17*y[1] + 59*y[2] + 43*y[3] + 49*y[4]
     @inbounds retval += 49*y[end-3] + 43*y[end-2] + 59*y[end-1] + 17*y[end]
     retval /= 48
@@ -67,6 +67,6 @@ function integrate{X<:Real, Y<:Real}(x::Vector{X}, y::Vector{Y}, ::SimpsonEvenFa
     @inbounds return (x[end] - x[1]) / (length(y) - 1) * retval
 end
 
-integrate{X<:Real, Y<:Real}(x::Vector{X}, y::Vector{Y}) = integrate(x, y, TrapezoidalFast())
+integrate{X<:Real, Y<:Real}(x::AbstractVector{X}, y::AbstractVector{Y}) = integrate(x, y, TrapezoidalFast())
 
 end

--- a/src/NumericalIntegration.jl
+++ b/src/NumericalIntegration.jl
@@ -17,32 +17,30 @@ immutable TrapezoidalEvenFast <: IntegrationMethod end
 immutable SimpsonEven         <: IntegrationMethod end # https://en.wikipedia.org/wiki/Simpson%27s_rule#Alternative_extended_Simpson.27s_rule
 immutable SimpsonEvenFast     <: IntegrationMethod end
 
-integrate{T<:AbstractFloat}(x::Vector{T}, y::Vector{T}, method::IntegrationMethod=Trapezoidal()) = integrate(x, y, method)
-
-function integrate{T<:AbstractFloat}(x::Vector{T}, y::Vector{T}, ::Trapezoidal)
-    @assert length(x) == length(y) "x and y vectors must be of the same length!"
-    retval = zero(eltype(x))
+function integrate{X<:Real, Y<:Real}(x::Vector{X}, y::Vector{Y}, ::Trapezoidal)
+  @assert length(x) == length(y) "x and y vectors must be of the same length!"
+  retval = zero(promote(x[1], y[1])[1])
     for i in 1 : length(y)-1
-        retval += (x[i+1] - x[i]) * (y[i] + y[i+1])
+      retval += (x[i+1] - x[i]) * (y[i] + y[i+1])
     end
-    return 0.5 * retval
+  return 0.5 * retval
 end
 
-function integrate{T<:AbstractFloat}(x::Vector{T}, y::Vector{T}, ::TrapezoidalEven)
+function integrate{X<:Real, Y<:Real}(x::Vector{X}, y::Vector{Y}, ::TrapezoidalEven)
     @assert length(x) == length(y) "x and y vectors must be of the same length!"
     return 0.5 * (x[end] - x[1]) / (length(y) - 1) * (y[1] + y[end] + sum(y[2:end-1]))
 end
 
-function integrate{T<:AbstractFloat}(x::Vector{T}, y::Vector{T}, ::TrapezoidalFast)
-    retval = zero(eltype(x))
+function integrate{X<:Real, Y<:Real}(x::Vector{X}, y::Vector{Y}, ::TrapezoidalFast)
+    retval = zero(promote(x[1], y[1])[1])
     @fastmath @simd for i in 1 : length(y)-1
         @inbounds retval += (x[i+1] - x[i]) * (y[i] + y[i+1])
     end
     return 0.5 * retval
 end
 
-function integrate{T<:AbstractFloat}(x::Vector{T}, y::Vector{T}, ::TrapezoidalEvenFast)
-    retval = zero(eltype(x))
+function integrate{X<:Real, Y<:Real}(x::Vector{X}, y::Vector{Y}, ::TrapezoidalEvenFast)
+    retval = zero(promote(x[1], y[1])[1])
     N = length(y) - 1
     @fastmath @simd for i in 2 : N
         @inbounds retval += y[i]
@@ -50,7 +48,7 @@ function integrate{T<:AbstractFloat}(x::Vector{T}, y::Vector{T}, ::TrapezoidalEv
     @inbounds return (x[end] - x[1]) / N * (retval + 0.5*y[1] + 0.5*y[end])
 end
 
-function integrate{T<:AbstractFloat}(x::Vector{T}, y::Vector{T}, ::SimpsonEven)
+function integrate{X<:Real, Y<:Real}(x::Vector{X}, y::Vector{Y}, ::SimpsonEven)
     @assert length(x) == length(y) "x and y vectors must be of the same length!"
     retval = (17*y[1] + 59*y[2] + 43*y[3] + 49*y[4] + 49*y[end-3] + 43*y[end-2] + 59*y[end-1] + 17*y[end]) / 48
     for i in 5 : length(y) - 1
@@ -59,7 +57,7 @@ function integrate{T<:AbstractFloat}(x::Vector{T}, y::Vector{T}, ::SimpsonEven)
     return (x[end] - x[1]) / (length(y) - 1) * retval
 end
 
-function integrate{T<:AbstractFloat}(x::Vector{T}, y::Vector{T}, ::SimpsonEvenFast)
+function integrate{X<:Real, Y<:Real}(x::Vector{X}, y::Vector{Y}, ::SimpsonEvenFast)
     @inbounds retval = 17*y[1] + 59*y[2] + 43*y[3] + 49*y[4]
     @inbounds retval += 49*y[end-3] + 43*y[end-2] + 59*y[end-1] + 17*y[end]
     retval /= 48
@@ -68,5 +66,7 @@ function integrate{T<:AbstractFloat}(x::Vector{T}, y::Vector{T}, ::SimpsonEvenFa
     end
     @inbounds return (x[end] - x[1]) / (length(y) - 1) * retval
 end
+
+integrate{X<:Real, Y<:Real}(x::Vector{X}, y::Vector{Y}) = integrate(x, y, TrapezoidalFast())
 
 end


### PR DESCRIPTION
This allows for `linspace` and similar objects to be used as either `x` or `y`