### PR TITLE
Correct the TrapezoidalEven() method and optimize the performance a little bit.

### DIFF
--- a/src/NumericalIntegration.jl
+++ b/src/NumericalIntegration.jl
@@ -28,7 +28,7 @@ end
 
 function integrate{X<:Number, Y<:Number}(x::AbstractVector{X}, y::AbstractVector{Y}, ::TrapezoidalEven)
     @assert length(x) == length(y) "x and y vectors must be of the same length!"
-    return 0.5 * (x[end] - x[1]) / (length(y) - 1) * (y[1] + y[end] + sum(y[2:end-1]))
+    return (x[2] - x[1]) * (0.5 * (y[1] + y[end]) + sum(y[2:end-1]))
 end
 
 function integrate{X<:Number, Y<:Number}(x::AbstractVector{X}, y::AbstractVector{Y}, ::TrapezoidalFast)

--- a/src/NumericalIntegration.jl
+++ b/src/NumericalIntegration.jl
@@ -45,7 +45,7 @@ function integrate{X<:Number, Y<:Number}(x::AbstractVector{X}, y::AbstractVector
     @fastmath @simd for i in 2 : N
         @inbounds retval += y[i]
     end
-    @inbounds return (x[end] - x[1]) / N * (retval + 0.5*y[1] + 0.5*y[end])
+    @inbounds return (x[2] - x[1]) * (retval + 0.5*y[1] + 0.5*y[end])
 end
 
 function integrate{X<:Number, Y<:Number}(x::AbstractVector{X}, y::AbstractVector{Y}, ::SimpsonEven)
@@ -54,7 +54,7 @@ function integrate{X<:Number, Y<:Number}(x::AbstractVector{X}, y::AbstractVector
     for i in 5 : length(y) - 1
         retval += y[i]
     end
-    return (x[end] - x[1]) / (length(y) - 1) * retval
+    return (x[2] - x[1]) * retval
 end
 
 function integrate{X<:Number, Y<:Number}(x::AbstractVector{X}, y::AbstractVector{Y}, ::SimpsonEvenFast)
@@ -64,7 +64,7 @@ function integrate{X<:Number, Y<:Number}(x::AbstractVector{X}, y::AbstractVector
     @fastmath @inbounds for i in 5 : length(y)-1
         retval += y[i]
     end
-    @inbounds return (x[end] - x[1]) / (length(y) - 1) * retval
+    @inbounds return (x[2] - x[1]) * retval
 end
 
 integrate{X<:Number, Y<:Number}(x::AbstractVector{X}, y::AbstractVector{Y}) = integrate(x, y, TrapezoidalFast())

--- a/src/NumericalIntegration.jl
+++ b/src/NumericalIntegration.jl
@@ -17,7 +17,7 @@ immutable TrapezoidalEvenFast <: IntegrationMethod end
 immutable SimpsonEven         <: IntegrationMethod end # https://en.wikipedia.org/wiki/Simpson%27s_rule#Alternative_extended_Simpson.27s_rule
 immutable SimpsonEvenFast     <: IntegrationMethod end
 
-function integrate{X<:Real, Y<:Real}(x::AbstractVector{X}, y::AbstractVector{Y}, ::Trapezoidal)
+function integrate{X<:Number, Y<:Number}(x::AbstractVector{X}, y::AbstractVector{Y}, ::Trapezoidal)
   @assert length(x) == length(y) "x and y vectors must be of the same length!"
   retval = zero(promote(x[1], y[1])[1])
     for i in 1 : length(y)-1
@@ -26,12 +26,12 @@ function integrate{X<:Real, Y<:Real}(x::AbstractVector{X}, y::AbstractVector{Y},
   return 0.5 * retval
 end
 
-function integrate{X<:Real, Y<:Real}(x::AbstractVector{X}, y::AbstractVector{Y}, ::TrapezoidalEven)
+function integrate{X<:Number, Y<:Number}(x::AbstractVector{X}, y::AbstractVector{Y}, ::TrapezoidalEven)
     @assert length(x) == length(y) "x and y vectors must be of the same length!"
     return 0.5 * (x[end] - x[1]) / (length(y) - 1) * (y[1] + y[end] + sum(y[2:end-1]))
 end
 
-function integrate{X<:Real, Y<:Real}(x::AbstractVector{X}, y::AbstractVector{Y}, ::TrapezoidalFast)
+function integrate{X<:Number, Y<:Number}(x::AbstractVector{X}, y::AbstractVector{Y}, ::TrapezoidalFast)
     retval = zero(promote(x[1], y[1])[1])
     @fastmath @simd for i in 1 : length(y)-1
         @inbounds retval += (x[i+1] - x[i]) * (y[i] + y[i+1])
@@ -39,7 +39,7 @@ function integrate{X<:Real, Y<:Real}(x::AbstractVector{X}, y::AbstractVector{Y},
     return 0.5 * retval
 end
 
-function integrate{X<:Real, Y<:Real}(x::AbstractVector{X}, y::AbstractVector{Y}, ::TrapezoidalEvenFast)
+function integrate{X<:Number, Y<:Number}(x::AbstractVector{X}, y::AbstractVector{Y}, ::TrapezoidalEvenFast)
     retval = zero(promote(x[1], y[1])[1])
     N = length(y) - 1
     @fastmath @simd for i in 2 : N
@@ -48,7 +48,7 @@ function integrate{X<:Real, Y<:Real}(x::AbstractVector{X}, y::AbstractVector{Y},
     @inbounds return (x[end] - x[1]) / N * (retval + 0.5*y[1] + 0.5*y[end])
 end
 
-function integrate{X<:Real, Y<:Real}(x::AbstractVector{X}, y::AbstractVector{Y}, ::SimpsonEven)
+function integrate{X<:Number, Y<:Number}(x::AbstractVector{X}, y::AbstractVector{Y}, ::SimpsonEven)
     @assert length(x) == length(y) "x and y vectors must be of the same length!"
     retval = (17*y[1] + 59*y[2] + 43*y[3] + 49*y[4] + 49*y[end-3] + 43*y[end-2] + 59*y[end-1] + 17*y[end]) / 48
     for i in 5 : length(y) - 1
@@ -57,7 +57,7 @@ function integrate{X<:Real, Y<:Real}(x::AbstractVector{X}, y::AbstractVector{Y},
     return (x[end] - x[1]) / (length(y) - 1) * retval
 end
 
-function integrate{X<:Real, Y<:Real}(x::AbstractVector{X}, y::AbstractVector{Y}, ::SimpsonEvenFast)
+function integrate{X<:Number, Y<:Number}(x::AbstractVector{X}, y::AbstractVector{Y}, ::SimpsonEvenFast)
     @inbounds retval = 17*y[1] + 59*y[2] + 43*y[3] + 49*y[4]
     @inbounds retval += 49*y[end-3] + 43*y[end-2] + 59*y[end-1] + 17*y[end]
     retval /= 48
@@ -67,6 +67,6 @@ function integrate{X<:Real, Y<:Real}(x::AbstractVector{X}, y::AbstractVector{Y},
     @inbounds return (x[end] - x[1]) / (length(y) - 1) * retval
 end
 
-integrate{X<:Real, Y<:Real}(x::AbstractVector{X}, y::AbstractVector{Y}) = integrate(x, y, TrapezoidalFast())
+integrate{X<:Number, Y<:Number}(x::AbstractVector{X}, y::AbstractVector{Y}) = integrate(x, y, TrapezoidalFast())
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,10 @@ using Base.Test
 methods = [Trapezoidal(), TrapezoidalEven(), TrapezoidalFast(), TrapezoidalEvenFast(), SimpsonEven(), SimpsonEvenFast()]
 x = collect(-π : π/1000 : π)
 y = sin.(x)
+p = collect(0 : π/1000 : π)
+q = sin.(p)
 for method in methods
     println(string("Testing method: ", typeof(method)))
     @test abs(integrate(x, y, method)) < 1e-4
+    @test abs(integrate(p, q, method)-2.0) < 1e-4
 end


### PR DESCRIPTION
@dextorious I think the original formula for the `TrapezoidalEven()` method is NOT correct and your testing example cannot detect it since the given integrant is symmetrically distributed below and above zero. So, I made the correction for the formula and added an asymmetric testing instance. 

I have also simplified some formulas in your other methods to boost the performance a little bit. 

Of course, you can put more testing cases from [QuadGK.jl](https://github.com/JuliaMath/QuadGK.jl/blob/master/test/runtests.jl), for example. 

Thanks,
Qi