### PR TITLE
Added function to perform cumulative integrals, and array inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,21 @@ Do note that while the code is trivial, it has not been extensively tested and d
 ```julia
 # setup some data
 x = collect(-π : π/1000 : π)
-y = sin(x)
+y = sin.(x)
 
 # integrate using the default TrapezoidalFast method
 integrate(x, y)
 
 # integrate using a specific method
 integrate(x, y, SimpsonEven())
+
+# compute cumulative integral
+Y = cintegrate(x, y)
+
+# compute cumulative integral for each column of an array
+z = [sin.(x) cos.(x) exp.(x/pi)]
+Z = cintegrate(x, y)
+
 ```
 
 The currently available methods are:
@@ -32,5 +40,7 @@ The currently available methods are:
 - TrapezoidalEvenFast
 - SimpsonEven
 - SimpsonEvenFast
+
+Only Trapezoidal methods are available for cumumlative integrals.
 
 All methods containing "Even" in the name assume evenly spaced data. All methods containing "Fast" omit basic correctness checks and focus on performance. Consequently, the fast methods will segfault or produce incorrect results if you supply incorrect data (vectors of different lengths, etc.).

--- a/README.md
+++ b/README.md
@@ -25,18 +25,22 @@ integrate(x, y)
 integrate(x, y, SimpsonEven())
 
 # compute cumulative integral
-Y = cintegrate(x, y)
+Y = cumul_integrate(x, y)
 
 # compute cumulative integral for each column of an array
 z = [sin.(x) cos.(x) exp.(x/pi)]
-Z = cintegrate(x, y)
+Z = cumul_integrate(x, z)
+
+# compute cumulative integral for each line of an array
+zp = permutedims(z) 
+ZP = cumul_integrate(x, zp, dims=1)
 
 ```
 
 The currently available methods are:
-- Trapezoidal
+- Trapezoidal (default)
 - TrapezoidalEven
-- TrapezoidalFast (default)
+- TrapezoidalFast
 - TrapezoidalEvenFast
 - SimpsonEven
 - SimpsonEvenFast

--- a/src/NumericalIntegration.jl
+++ b/src/NumericalIntegration.jl
@@ -1,6 +1,6 @@
 module NumericalIntegration
 
-export integrate
+export integrate, cintegrate
 export Trapezoidal, TrapezoidalEven, TrapezoidalFast, TrapezoidalEvenFast
 export SimpsonEven, SimpsonEvenFast
 export IntegrationMethod
@@ -16,11 +16,41 @@ struct SimpsonEvenFast     <: IntegrationMethod end
 
 const HALF = 1//2
 
+
+#documentation
+
+"""
+    integrate(x,y...)
+
+Compute numerical integral of y(x) from x=x[1] to x=x[end]. Return a scalar of the same type as the input. If not method is supplied, use TrapezdoialFast.
+"""
+function integrate(x,y...) end
+
+
+"""
+    cintegrate(x,y...)
+
+Compute cumulative numerical integral of y(x) from x=x[1] to x=x[end]. Return a vector with elements of the same type as the input. If not method is supplied, use TrapezdoialFast.
+"""
+function cintegrate(x,y...) end
+
+#implementation
+
 function _zero(x,y)
     ret = zero(eltype(x)) + zero(eltype(y))
     ret / 2
 end
 
+function _zeros(x::AbstractVector,y::AbstractVector)
+    ret = zeros(eltype(x),size(x)) + zeros(eltype(y),size(y))
+    ret / 2
+end
+
+"""
+    integrate(x::AbstractVector, y::AbstractVector, ::Trapezoidal)
+
+Use Trapezoidal rule.
+"""
 function integrate(x::AbstractVector, y::AbstractVector, ::Trapezoidal)
     @assert length(x) == length(y) "x and y vectors must be of the same length!"
     retval = _zero(x,y)
@@ -30,11 +60,21 @@ function integrate(x::AbstractVector, y::AbstractVector, ::Trapezoidal)
     return HALF * retval
 end
 
+"""
+    integrate(x::AbstractVector, y::AbstractVector, ::TrapezoidalEven)
+
+Use Trapezoidal rule, assuming evenly spaced vector x.
+"""
 function integrate(x::AbstractVector, y::AbstractVector, ::TrapezoidalEven)
     @assert length(x) == length(y) "x and y vectors must be of the same length!"
     return (x[2] - x[1]) * (HALF * (y[1] + y[end]) + sum(y[2:end-1]))
 end
 
+"""
+    integrate(x::AbstractVector, y::AbstractVector, ::TrapezoidalFast)
+
+Use Trapezoidal rule. Unsafe method: no bound checking. This is the default when no method is supplied.
+"""
 function integrate(x::AbstractVector, y::AbstractVector, ::TrapezoidalFast)
     retval = _zero(x,y)
     @fastmath @simd for i in 1 : length(y)-1
@@ -43,6 +83,11 @@ function integrate(x::AbstractVector, y::AbstractVector, ::TrapezoidalFast)
     return HALF * retval
 end
 
+"""
+    integrate(x::AbstractVector, y::AbstractVector, ::TrapezoidalEvenFast)
+
+Use Trapezoidal rule, assuming evenly spaced vector x. Unsafe method: no bound checking.
+"""
 function integrate(x::AbstractVector, y::AbstractVector, ::TrapezoidalEvenFast)
     retval = _zero(x,y)
     N = length(y) - 1
@@ -52,6 +97,11 @@ function integrate(x::AbstractVector, y::AbstractVector, ::TrapezoidalEvenFast)
     @inbounds return (x[2] - x[1]) * (retval + HALF*y[1] + HALF*y[end])
 end
 
+"""
+    integrate(x::AbstractVector, y::AbstractVector, ::SimpsonEven)
+
+Use Simpson's rule, assuming evenly spaced vector x. 
+"""
 function integrate(x::AbstractVector, y::AbstractVector, ::SimpsonEven)
     @assert length(x) == length(y) "x and y vectors must be of the same length!"
     retval = (17*y[1] + 59*y[2] + 43*y[3] + 49*y[4] + 49*y[end-3] + 43*y[end-2] + 59*y[end-1] + 17*y[end]) / 48
@@ -61,6 +111,11 @@ function integrate(x::AbstractVector, y::AbstractVector, ::SimpsonEven)
     return (x[2] - x[1]) * retval
 end
 
+"""
+    integrate(x::AbstractVector, y::AbstractVector, ::SimpsonEven)
+
+Use Simpson's rule, assuming evenly spaced vector x.  Unsafe method: no bound checking.
+"""
 function integrate(x::AbstractVector, y::AbstractVector, ::SimpsonEvenFast)
     @inbounds retval = 17*y[1] + 59*y[2] + 43*y[3] + 49*y[4]
     @inbounds retval += 49*y[end-3] + 43*y[end-2] + 59*y[end-1] + 17*y[end]
@@ -71,6 +126,90 @@ function integrate(x::AbstractVector, y::AbstractVector, ::SimpsonEvenFast)
     @inbounds return (x[2] - x[1]) * retval
 end
 
+"""
+    integrate(x::AbstractVector, y::AbstractArray, method)
+
+When y is an array, compute integral for each column.
+"""
+function integrate(x::AbstractVector, y::AbstractArray, M::IntegrationMethod)
+    out = [integrate(x,y[:,j],M) for j=1:size(y,2)]
+    return out
+end
+
+
+# cumulative integrals
+
+"""
+    cintegrate(x::AbstractVector, y::AbstractVector, ::Trapezoidal)
+
+Use Trapezoidal rule.
+"""
+function cintegrate(x::AbstractVector, y::AbstractVector, ::Trapezoidal)
+    @assert length(x) == length(y) "x and y vectors must be of the same length!"
+    retarr = _zeros(x,y)
+    for i in 2 : length(y)
+        retarr[i] = retarr[i-1] + (x[i] - x[i-1]) * (y[i] + y[i-1])
+    end
+    return HALF * retarr
+end
+
+"""
+    cintegrate(x::AbstractVector, y::AbstractVector, ::TrapezoidalEven)
+
+Use Trapezoidal rule, assuming evenly spaced vector x.
+"""
+function cintegrate(x::AbstractVector, y::AbstractVector, ::TrapezoidalEven)
+    @assert length(x) == length(y) "x and y vectors must be of the same length!"
+    retarr = _zeros(x,y)
+    for i in 2 : length(y)
+        retarr[i] = retarr[i-1] + (y[i-1] + y[i])
+    end
+    return (x[2] - x[1]) * HALF * retarr
+end
+
+"""
+    cintegrate(x::AbstractVector, y::AbstractVector, ::TrapezoidalFast)
+
+Use Trapezoidal rule. Unsafe method: no bound checking. This is the default when no method is supplied.
+"""
+function cintegrate(x::AbstractVector, y::AbstractVector, ::TrapezoidalFast)
+    retarr = _zeros(x,y)
+    @fastmath for i in 2 : length(y) #not sure if @simd can do anything here
+        @inbounds retarr[i] = retarr[i-1] + (x[i] - x[i-1]) * (y[i] + y[i-1])
+    end
+    return HALF * retarr
+end
+
+"""
+    cintegrate(x::AbstractVector, y::AbstractVector, ::TrapezoidalEvenFast)
+
+Use Trapezoidal rule, assuming evenly spaced vector x. Unsafe method: no bound checking.
+"""
+function cintegrate(x::AbstractVector, y::AbstractVector, ::TrapezoidalEvenFast)
+    retarr = _zeros(x,y)
+    @fastmath for i in 2 : length(y)
+        @inbounds retarr[i] = retarr[i-1] + (y[i] + y[i-1])
+    end
+    @inbounds return (x[2] - x[1]) * HALF * retarr
+end
+
+"""
+    cintegrate(x::AbstractVector, y::AbstractArray, method)
+
+When y is an array, compute integral for each column.
+"""
+function cintegrate(x::AbstractVector, y::AbstractArray, M::IntegrationMethod)
+    return hcat([cintegrate(x,y[:,j],M) for j=1:size(y,2)]...)
+end
+
+
+#default behaviour
 integrate(x::AbstractVector, y::AbstractVector) = integrate(x, y, TrapezoidalFast())
+
+integrate(x::AbstractVector, y::AbstractArray) = integrate(x,y,TrapezoidalFast())
+
+cintegrate(x::AbstractVector, y::AbstractVector) = cintegrate(x, y, TrapezoidalFast())
+
+cintegrate(x::AbstractVector, y::AbstractArray) = cintegrate(x,y,TrapezoidalFast())
 
 end


### PR DESCRIPTION
The idea was to be able to compute numerical integrals for each value of input x, simiilar to what matlab does with cumtrapz instead of trapz. This is only relevant for Traezoidal method because higher order methods require vales of integrand at more than 2 points, so the ends would be difficult to deal with.

Also added methods to get integrals for each column when input y in an array.
Also added some minimal documentation for each function.

I am aware that the implementation is not very generic but it seems to work for the intended purpose...