### PR TITLE
memory efficient n-dimensional integration

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["dextorious"]
 version = "0.2.1"
 
 [deps]
+Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 


### PR DESCRIPTION
Implemented much more efficient n-dimensional integration methods.  I added in Trapezoidal, TrapezoidalFast, and TrapezoidalEvenFast.  Trapezoidal just calls TrapezoidalFast but checks the input first.  I did pull in the package Interpolations but I think it is well worth it.

    julia> X = (sort(rand(100)), sort(rand(99)), sort(rand(98)));

    julia> Y = [a^2 + 2*b + sqrt(c) for a=X[1],b=X[2],c=X[3]];

    julia> integrate(X,Y);

    julia> @time integrate(X,Y)
      0.136895 seconds (31 allocations: 6.125 KiB)
    1.841068413158726

    julia> X = (range(0,stop=1,length=100), range(0,stop=1,length=99), 
    range(0,stop=1,length=98));

    julia> Y = [a^2 + 2*b + sqrt(c) for a=X[1],b=X[2],c=X[3]];

    julia> @time integrate(X,Y,TrapezoidalEvenFast());

    julia> @time integrate(X,Y,TrapezoidalEvenFast());
      0.092801 seconds (27 allocations: 7.403 MiB)
    1.9998038288258926