### PR TITLE
Use specialized methods for ranges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,12 @@ os:
 julia:
   - 1.2
   - 1.3
-  - 1.4
+  - 1
   - nightly
 notifications:
   email: false
-# uncomment the following lines to override the default test script
-#script:
-#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-#  - julia -e 'Pkg.clone(pwd()); Pkg.build("NumericalIntegration"); Pkg.test("NumericalIntegration"; coverage=true)'
 after_success:
-  # push coverage results to Coveralls
-  - julia -e 'cd(Pkg.dir("NumericalIntegration")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
-  # push coverage results to Codecov
-  - julia -e 'cd(Pkg.dir("NumericalIntegration")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+  - if [[ $TRAVIS_JULIA_VERSION = 1 ]] && [[ $TRAVIS_OS_NAME = linux ]]; then
+      julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())';
+      julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())';
+    fi


### PR DESCRIPTION
This PR adds dispatches for `::AbstractRange` that forward `::IntegrationMethod` to `::IntegrationMethodEven` to exploit the special structure of the grid. Moreover, the implementation is simplified by forwarding regular methods to the fast implementations after performing all necessary checks.

Additionally, some warnings about deprecated use of `::Number + ::StaticArray` are resolved by getting rid of all initializations with zeros.