### PR TITLE
Add Simpson's method on irregular grid + tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,6 @@ version = "0.3.3"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 Interpolations = "0.13"
@@ -19,6 +18,7 @@ InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [targets]
 test = ["Test", "InteractiveUtils", "StaticArrays", "HCubature", "Unitful", "Random"]

--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "0.3.3"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 Interpolations = "0.13"
@@ -20,4 +21,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["Test", "InteractiveUtils", "StaticArrays", "HCubature", "Unitful"]
+test = ["Test", "InteractiveUtils", "StaticArrays", "HCubature", "Unitful", "Random"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,9 +27,9 @@ end
 
 @testset "compare with analytic result, uneven grid" begin
     x1 = [-π;  sort(rand(1000)*2π .- π); π] # even number
-    y1 = sin.(x)
+    y1 = sin.(x1)
     x2 = [-π;  sort(rand(1001)*2π .- π); π] # odd number
-    y2 = sin.(x)
+    y2 = sin.(x2)
     for M in [Trapezoidal, TrapezoidalFast, Simpson, SimpsonFast]
         for T in [Float32, Float64, BigFloat]
             for (xs,ys,val,atol) in [

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,8 @@ using Test
 using InteractiveUtils # for subtypes
 using StaticArrays
 using HCubature # for testing n-dimensional integration
+using Random
+Random.seed!(124)
 
 @testset "compare with analytic result" begin
     x = collect(-π : 2*π/2048 : π)
@@ -16,6 +18,22 @@ using HCubature # for testing n-dimensional integration
                                      (p,q,2,1e-4),
                                   ]
                 result = @inferred integrate(T.(xs), T.(ys),M())
+                @test isapprox(result, val, atol=atol)
+                @test typeof(result) == T
+            end
+        end
+    end
+end
+
+@testset "compare with analytic result, uneven grid" begin
+    x = [-π;  sort(rand(2^10+1)*2π .- π); π]
+    y = sin.(x)
+    for M in [Trapezoidal, TrapezoidalFast, Simpson, SimpsonFast]
+        for T in [Float32, Float64, BigFloat]
+            for (xs,ys,val,atol) in [
+                                     (x, y, 0, 1e-4),
+                                  ]
+                result = @inferred integrate(T.(xs), T.(ys), M())
                 @test isapprox(result, val, atol=atol)
                 @test typeof(result) == T
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,12 +26,15 @@ Random.seed!(124)
 end
 
 @testset "compare with analytic result, uneven grid" begin
-    x = [-π;  sort(rand(2^10+1)*2π .- π); π]
-    y = sin.(x)
+    x1 = [-π;  sort(rand(1000)*2π .- π); π] # even number
+    y1 = sin.(x)
+    x2 = [-π;  sort(rand(1001)*2π .- π); π] # odd number
+    y2 = sin.(x)
     for M in [Trapezoidal, TrapezoidalFast, Simpson, SimpsonFast]
         for T in [Float32, Float64, BigFloat]
             for (xs,ys,val,atol) in [
-                                     (x, y, 0, 1e-4),
+                                     (x1, y1, 0, 1e-4),
+                                     (x2, y2, 0, 1e-4),
                                   ]
                 result = @inferred integrate(T.(xs), T.(ys), M())
                 @test isapprox(result, val, atol=atol)


### PR DESCRIPTION
Added the methods 
```
integrate(x::AbstractVector, y::AbstractVector, ::Simpson)
integrate(x::AbstractVector, y::AbstractVector, ::SimpsonFast)
```
which work on irregular grids. 

Also added a `testset` to test the new methods (together with Trapezoidal/Trapezoidal Fast)

Example:

```
julia> x = LinRange(0, sqrt(π/2), 10).^2
10-element Vector{Float64}:
 0.0
 0.01939254724438143
 0.07757018897752573
 0.17453292519943292
 0.3102807559101029
 0.484813681109536
 0.6981317007977317
 0.9502348149746904
 1.2411230236404116
 1.5707963267948963

julia> y = sin.(x)
10-element Vector{Float64}:
 0.0
 0.019391331771824363
 0.0774924206719309
 0.1736481776669303
 0.305325997695113
 0.4660435197025388
 0.6427876096865393
 0.8135520702629675
 0.9461481568757503
 1.0

julia> integrate(x, y, Simpson())
0.9998087840617803 #analytic result is 1
```