### PR TITLE
Compatibility with Interpolations ≥ 0.14.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NumericalIntegration"
 uuid = "e7bfaba1-d571-5449-8927-abc22e82249b"
 authors = ["dextorious"]
-version = "0.3.3"
+version = "0.3.4"
 
 [deps]
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
@@ -9,8 +9,8 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
 [compat]
-Interpolations = "0.13"
 julia = "0.7, 1"
+Interpolations = "≥ 0.14.3"
 
 [extras]
 HCubature = "19dc6840-f33b-545b-b366-655c7e3ffd49"

--- a/src/NumericalIntegration.jl
+++ b/src/NumericalIntegration.jl
@@ -207,7 +207,7 @@ function integrate(X::NTuple{N,AbstractVector}, Y::AbstractArray{T,N}, ::Trapezo
     midpnts = map(_midpoints, X)
     Δ(x::AbstractVector) = length(x) > 1 ? diff(x) : 1
     Δxs = map(Δ, X)
-    interp = LinearInterpolation(X,Y)
+    interp = linear_interpolation(X,Y)
     f((Δx,x)) = prod(Δx)*interp(x...)
     return sum(f, zip(product(Δxs...), product(midpnts...)))
 end
@@ -216,7 +216,7 @@ function integrate(X::NTuple{N,AbstractVector}, Y::AbstractArray{T,N}, ::Trapezo
     midpnts = map(_midpoints, X)
     Δ(x::AbstractVector) = length(x) > 1 ? x[2] - x[1] : 1
     Δx = prod(Δ, X)
-    interp = LinearInterpolation(X,Y)
+    interp = linear_interpolation(X,Y)
     f(x) = interp(x...)
     return Δx*sum(f, product(midpnts...))
 end
@@ -225,7 +225,7 @@ function integrate(X::NTuple{N,AbstractRange}, Y::AbstractArray{T,N}, ::Trapezoi
     midpnts = map(_midpoints, X)
     Δ(x::AbstractVector) = length(x) > 1 ? step(x) : 1
     Δx = prod(Δ, X)
-    interp = LinearInterpolation(X,Y)
+    interp = linear_interpolation(X,Y)
     f(x) = interp(x...)
     return Δx*sum(f, product(midpnts...))
 end


### PR DESCRIPTION
Since version 0.14.2 the Interpolations package changed some of its notation from CamelCase to snake_case in accordance to Julia's recommendations.
I simply adjusted the package so that it is now compatible with the latest notation of Interpolations.